### PR TITLE
Update Docker Compose to include environment variable defaults

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,11 @@ services:
     image: ghcr.io/ton-bypass/node:latest
     restart: always
     network_mode: host
+    env_file: .env
     environment:
-      SSL_CLIENT_CERT_FILE: "/var/lib/marzban-node/ssl_client_cert.pem"
+      SERVICE_PORT: ${SERVICE_PORT:-62050}
+      XRAY_API_PORT: ${XRAY_API_PORT:-62051}
+      SSL_CLIENT_CERT_FILE: ${SSL_CLIENT_CERT_FILE:-/var/lib/marzban-node/ssl_client_cert.pem}
 
     volumes:
       - /var/lib/marzban-node:/var/lib/marzban-node


### PR DESCRIPTION
This PR updates the Docker Compose configuration to set default values for environment variables, enhancing flexibility and ease of use. The changes include the addition of an `env_file` directive and default values for `SERVICE_PORT`, `XRAY_API_PORT`, and `SSL_CLIENT_CERT_FILE`. This ensures that the application can run with sensible defaults if specific environment variables are not provided.