### PR TITLE
Update rpyc version to 5.3.1 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ pydantic_core==2.16.2
 pyOpenSSL>=23.0.0
 python-decouple==3.7
 python-dotenv==0.21.1
-rpyc==5.3.0
+rpyc==5.3.1
 sniffio==1.3.0
 starlette==0.36.3
 typing_extensions==4.9.0


### PR DESCRIPTION
This pull request updates the rpyc package version from 5.3.0 to 5.3.1 in the requirements.txt file to ensure compatibility and incorporate the latest features and fixes.