### PR TITLE
Change Node service restart policy in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   node:
     image: ghcr.io/ton-bypass/node:latest
-    restart: always
+    restart: unless-stopped
     network_mode: host
     env_file: .env
     environment:


### PR DESCRIPTION
This PR updates the Node service's restart policy in the `docker-compose.yml` file from 'always' to 'unless-stopped', ensuring that the service will only restart unless it has been explicitly stopped. This change improves resource management and service behavior in various deployment scenarios.