### PR TITLE
Update Dependabot configuration for GitHub Actions weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
+  - package-ecosystem: pip
+    directory: /
     schedule:
-      interval: "daily"
-    target-branch: "dev"
+      interval: daily
+    target-branch: dev
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: dev


### PR DESCRIPTION
This PR updates the Dependabot configuration to include GitHub Actions, setting it to check for updates on a weekly basis. The existing configuration for Python packages has also been reformatted for consistency.