### PR TITLE
Upgrade dependencies: websockets to 13.1 and auto-assign-issue to v2

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     steps:
     - name: 'Auto-assign issue'
-      uses: pozil/auto-assign-issue@v1
+      uses: pozil/auto-assign-issue@v2
       with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           assignees: fakedude

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ sniffio==1.3.0
 starlette==0.36.3
 typing_extensions==4.9.0
 uvicorn==0.27.0.post1
-websockets==12.0
+websockets==13.1


### PR DESCRIPTION
This pull request updates the `websockets` library from version 12.0 to 13.1 and the `auto-assign-issue` action from version 1 to 2. These upgrades ensure compatibility with the latest features and improvements in both libraries. The changes include updating the respective references in the workflow and requirements files.